### PR TITLE
Use total forged, timestamp fix

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -10,5 +10,5 @@
         "addresses": [], // Add addresses to exlude
         "weightCap": 100000 // Remove accounts with cap greater or equal then value. `null` value will turn of this filter
     },
-    "weightCap": [50000, 70000, 100000] // Add weight cap rule to change accounts weight (example: account with weight 75k becomes 70k, 120k becomes 100)
+    "weightCap": [50000, 70000, 100000] // Add weight cap rule to change accounts weight (example: account with weight 75k becomes 70k, 120k becomes 100). Leave empty array if you will not use this
 }

--- a/scripts/utils/api.js
+++ b/scripts/utils/api.js
@@ -24,7 +24,7 @@ const getRewards = async (fromTimestamp, toTimestamp) => {
     fromTimestamp,
     toTimestamp
   });
-  const reward = fromRawLsk(data.rewards);
+  const reward = fromRawLsk(data.forged);
   const sharingReward = (reward * config.sharedPercent) / 100;
   return {
     reward,

--- a/scripts/utils/file.js
+++ b/scripts/utils/file.js
@@ -11,7 +11,7 @@ const getBalanceFile = () => {
         return fs.readFileSync(BALANCE_FILE);
     } catch (error) {
         const data = {
-            lastpayout: config.epochPoolTime,
+            lastpayout: config.epochPoolTime*1000,
             accounts: {},
         };
         fs.writeFileSync(BALANCE_FILE, data, { spaces: 2 });


### PR DESCRIPTION
This PR uses total forged fees+rewards instead rewards only to calculate sharing reward. 
Also it fix's issue with first start of script with UNIX timestamp in seconds in config.json.